### PR TITLE
Fix variable assignment and ensure it has a correct type

### DIFF
--- a/roles/wazuh/wazuh_agent/tasks/Linux.yml
+++ b/roles/wazuh/wazuh_agent/tasks/Linux.yml
@@ -298,8 +298,8 @@
 - name: Linux | Ensure Wazuh Agent service is in the desired state
   service:
     name: wazuh-agent
-    enabled: "{{ not wazuh_agent__packer_next_provision | ternary(true, false) }}"
-    state: "{{ not wazuh_agent__packer_next_provision | ternary('started', 'stopped') }}"
+    enabled: "{{ wazuh_agent__packer_next_provision | ternary(false, true) | bool }}"
+    state: "{{ wazuh_agent__packer_next_provision | ternary('stopped', 'started') }}"
   tags: config
   when: not ansible_check_mode
 


### PR DESCRIPTION
```
[WARNING]: The value "False" (type bool) was converted to "'False'" (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.

fatal: [default]: FAILED! => {"changed": false, "msg": "value of state must be one of: reloaded, restarted, started, stopped, got: False"}
```
